### PR TITLE
Fixed autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,10 @@
     "type": "project",
     "description": "The \"Symfony Empty Edition\" distribution",
     "autoload": {
-        "psr-4": { "AppBundle\\": "src/AppBundle" }
+        "psr-4": { "": "src" }
     },
     "autoload-dev": {
-        "psr-4": {
-            "AppBundle\\Tests\\": "tests"
-        }
+        "psr-4": { "Tests\\": "tests" }
     },
     "require": {
         "php": ">=5.3.3",


### PR DESCRIPTION
Made them more flexible:
- anything in `src` will be autoloaded with a regular namespace
- anything in `tests` will be autoloaded with a `Tests` preffix in the namespace
